### PR TITLE
[DEV] 카테고리 별 게시글 조회 기능

### DIFF
--- a/src/main/java/deepdivers/community/domain/member/controller/docs/MemberApiControllerDocs.java
+++ b/src/main/java/deepdivers/community/domain/member/controller/docs/MemberApiControllerDocs.java
@@ -112,5 +112,4 @@ public interface MemberApiControllerDocs {
         content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
     )
     ResponseEntity<API<List<AllMyPostsResponse>>> allWrittenPosts(Member member, Long categoryId, Long lastPostId);
-
 }

--- a/src/main/java/deepdivers/community/domain/post/controller/api/PostApiController.java
+++ b/src/main/java/deepdivers/community/domain/post/controller/api/PostApiController.java
@@ -6,6 +6,7 @@ import deepdivers.community.domain.member.model.Member;
 import deepdivers.community.domain.post.controller.docs.PostApiControllerDocs;
 import deepdivers.community.domain.post.dto.request.PostCreateRequest;
 import deepdivers.community.domain.post.dto.request.PostUpdateRequest;
+import deepdivers.community.domain.post.dto.response.PostAllReadResponse;
 import deepdivers.community.domain.post.dto.response.PostCreateResponse;
 import deepdivers.community.domain.post.dto.response.PostReadResponse;
 import deepdivers.community.domain.post.dto.response.PostUpdateResponse;
@@ -48,12 +49,19 @@ public class PostApiController implements PostApiControllerDocs {
 	}
 
 	@GetMapping
-	public ResponseEntity<API<List<PostReadResponse>>> getAllPosts(
-		@Auth final Member member
+	public ResponseEntity<API<List<PostAllReadResponse>>> getAllPosts(
+		@Auth final Member member,
+		@RequestParam(required = false) Long categoryId,
+		@RequestParam(required = false) Long lastPostId
 	) {
-		List<PostReadResponse> response = postService.getAllPosts();
+		if (lastPostId == null) {
+			lastPostId = Long.MAX_VALUE;  // lastPostId가 없으면 Long.MAX_VALUE 사용
+		}
+		List<PostAllReadResponse> response = postService.getAllPosts(lastPostId, categoryId);
 		return ResponseEntity.ok(API.of(PostStatusType.POST_VIEW_SUCCESS, response));
 	}
+
+
 
 	@Override
 	@PostMapping("/update/{postId}")

--- a/src/main/java/deepdivers/community/domain/post/controller/docs/PostApiControllerDocs.java
+++ b/src/main/java/deepdivers/community/domain/post/controller/docs/PostApiControllerDocs.java
@@ -2,10 +2,13 @@ package deepdivers.community.domain.post.controller.docs;
 
 import deepdivers.community.domain.common.API;
 import deepdivers.community.domain.common.NoContent;
+import deepdivers.community.domain.global.security.jwt.Auth;
+import deepdivers.community.domain.member.dto.response.AllMyPostsResponse;
 import deepdivers.community.domain.member.model.Member;
 import deepdivers.community.domain.post.dto.request.PostCreateRequest;
 import deepdivers.community.domain.post.dto.request.PostDeleteRequest;
 import deepdivers.community.domain.post.dto.request.PostUpdateRequest;
+import deepdivers.community.domain.post.dto.response.PostAllReadResponse;
 import deepdivers.community.domain.post.dto.response.PostCreateResponse;
 import deepdivers.community.domain.post.dto.response.PostReadResponse;
 import deepdivers.community.domain.post.dto.response.PostUpdateResponse;
@@ -16,6 +19,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -49,7 +53,7 @@ public interface PostApiControllerDocs {
 		description = "해당 게시글을 찾을 수 없습니다.",
 		content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
 	)
-	ResponseEntity<API<List<PostReadResponse>>> getAllPosts(Member member);
+	ResponseEntity<API<List<PostAllReadResponse>>> getAllPosts(Member member, Long categoryId, Long lastPostId);
 
 	@Operation(summary = "게시글 수정", description = "기존 게시글을 수정하는 기능")
 	@ApiResponse(

--- a/src/main/java/deepdivers/community/domain/post/controller/docs/PostOpenControllerDocs.java
+++ b/src/main/java/deepdivers/community/domain/post/controller/docs/PostOpenControllerDocs.java
@@ -1,6 +1,8 @@
 package deepdivers.community.domain.post.controller.docs;
 
 import deepdivers.community.domain.common.API;
+import deepdivers.community.domain.member.model.Member;
+import deepdivers.community.domain.post.dto.response.PostAllReadResponse;
 import deepdivers.community.domain.post.dto.response.PostReadResponse;
 import deepdivers.community.domain.global.exception.dto.response.ExceptionResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "5. 게시글", description = "비회원 게시글 조회 API")
 public interface PostOpenControllerDocs {
@@ -39,5 +42,5 @@ public interface PostOpenControllerDocs {
 		description = "해당 게시글을 찾을 수 없습니다.",
 		content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
 	)
-	ResponseEntity<API<List<PostReadResponse>>> getAllPosts();
+	ResponseEntity<API<List<PostAllReadResponse>>> getAllPosts(Long categoryId, Long lastPostId);
 }

--- a/src/main/java/deepdivers/community/domain/post/controller/open/PostOpenController.java
+++ b/src/main/java/deepdivers/community/domain/post/controller/open/PostOpenController.java
@@ -4,10 +4,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import deepdivers.community.domain.common.API;
 import deepdivers.community.domain.post.controller.docs.PostOpenControllerDocs;
+import deepdivers.community.domain.post.dto.response.PostAllReadResponse;
 import deepdivers.community.domain.post.dto.response.PostReadResponse;
 import deepdivers.community.domain.post.dto.response.statustype.PostStatusType;
 import deepdivers.community.domain.post.service.PostService;
@@ -35,8 +37,25 @@ public class PostOpenController implements PostOpenControllerDocs {
 
 	@Override
 	@GetMapping
-	public ResponseEntity<API<List<PostReadResponse>>> getAllPosts() {
-		List<PostReadResponse> response = postService.getAllPosts();
+	public ResponseEntity<API<List<PostAllReadResponse>>> getAllPosts(
+		@RequestParam(required = false) Long categoryId,
+		@RequestParam(required = false) Long lastPostId
+	) {
+
+		// Log 추가: 서비스 호출 전에 로그 추가
+		System.out.println("PostOpenController - getAllPosts() 호출 시작");
+
+		if (lastPostId == null) {
+			lastPostId = Long.MAX_VALUE;  // lastPostId가 없으면 Long.MAX_VALUE 사용
+		}
+		List<PostAllReadResponse> response = postService.getAllPosts(lastPostId, categoryId);
+
+		System.out.println("PostOpenController - postService에서 반환된 게시글 목록: " + response);
+
+		if (response.isEmpty()) {
+			System.out.println("PostOpenController - 빈 목록이 반환되었습니다.");
+		}
+
 		return ResponseEntity.ok(API.of(PostStatusType.POST_VIEW_SUCCESS, response));
 	}
 }

--- a/src/main/java/deepdivers/community/domain/post/dto/response/CountInfo.java
+++ b/src/main/java/deepdivers/community/domain/post/dto/response/CountInfo.java
@@ -1,0 +1,16 @@
+package deepdivers.community.domain.post.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CountInfo {
+	private Integer viewCount;
+	private Integer likeCount;
+	private Integer commentCount;
+}

--- a/src/main/java/deepdivers/community/domain/post/dto/response/MemberInfo.java
+++ b/src/main/java/deepdivers/community/domain/post/dto/response/MemberInfo.java
@@ -1,10 +1,16 @@
 package deepdivers.community.domain.post.dto.response;
 
-import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Schema(description = "게시글 작성자 정보")
-public record MemberInfo(
-	Long memberId,
-	String nickname,
-	String imageUrl
-) {}
+@Getter
+@Setter
+@NoArgsConstructor // Add this annotation to create a no-arg constructor
+@AllArgsConstructor // Existing constructor with arguments
+public class MemberInfo {
+	private Long memberId;
+	private String nickname;
+	private String imageUrl;
+}

--- a/src/main/java/deepdivers/community/domain/post/dto/response/PostAllReadResponse.java
+++ b/src/main/java/deepdivers/community/domain/post/dto/response/PostAllReadResponse.java
@@ -1,0 +1,24 @@
+package deepdivers.community.domain.post.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostAllReadResponse {
+	private Long postId;
+	private String title;
+	private String content;
+	private Long categoryId;
+	private MemberInfo memberInfo;
+	private CountInfo countInfo;
+	private List<String> hashtags;
+	private String createdAt;
+}

--- a/src/main/java/deepdivers/community/domain/post/dto/response/PostReadResponse.java
+++ b/src/main/java/deepdivers/community/domain/post/dto/response/PostReadResponse.java
@@ -14,9 +14,7 @@ public record PostReadResponse(
 	String content,
 	Long categoryId, // 카테고리 ID 사용
 	MemberInfo memberInfo, // 작성자 정보 포함
-	Integer viewCount,
-	Integer likeCount,
-	Integer commentCount,
+	CountInfo countInfo, // CountInfo 사용
 	List<String> hashtags, // 해시태그 포함
 	String createdAt // 생성일 포함
 ) {
@@ -31,10 +29,12 @@ public record PostReadResponse(
 				post.getMember().getNickname(), // 작성자 닉네임
 				post.getMember().getImageUrl() // 작성자 이미지 URL
 			),
-			post.getViewCount(),
-			post.getLikeCount(),
-			post.getCommentCount(),
-			post.getHashtags(),
+			new CountInfo(
+				post.getViewCount(), // 조회수
+				post.getLikeCount(), // 좋아요 수
+				post.getCommentCount() // 댓글 수
+			),
+			post.getHashtags(), // 해시태그 리스트
 			post.getCreatedAt().toString() // 생성일 포맷
 		);
 	}

--- a/src/main/java/deepdivers/community/domain/post/model/PostContent.java
+++ b/src/main/java/deepdivers/community/domain/post/model/PostContent.java
@@ -37,4 +37,5 @@ public class PostContent {
 		validator(content);
 		return new PostContent(content);
 	}
+
 }

--- a/src/main/java/deepdivers/community/domain/post/model/PostTitle.java
+++ b/src/main/java/deepdivers/community/domain/post/model/PostTitle.java
@@ -37,4 +37,5 @@ public class PostTitle {
 		validator(title);
 		return new PostTitle(title);
 	}
+
 }

--- a/src/main/java/deepdivers/community/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/deepdivers/community/domain/post/repository/PostQueryRepository.java
@@ -1,10 +1,15 @@
 package deepdivers.community.domain.post.repository;
 
 import deepdivers.community.domain.member.dto.response.AllMyPostsResponse;
+import deepdivers.community.domain.post.dto.response.PostAllReadResponse;
+import deepdivers.community.domain.post.dto.response.PostReadResponse;
+
 import java.util.List;
 
 public interface PostQueryRepository {
 
     List<AllMyPostsResponse> findAllMyPosts(final Long memberId, final Long lastTargetId, final Long categoryId);
+
+    List<PostAllReadResponse> findAllPosts(Long lastContentId, Long categoryId);
 
 }

--- a/src/main/java/deepdivers/community/domain/post/service/PostService.java
+++ b/src/main/java/deepdivers/community/domain/post/service/PostService.java
@@ -10,6 +10,7 @@ import deepdivers.community.domain.hashtag.repository.PostHashtagRepository;
 import deepdivers.community.domain.member.model.Member;
 import deepdivers.community.domain.post.dto.request.PostCreateRequest;
 import deepdivers.community.domain.post.dto.request.PostUpdateRequest;
+import deepdivers.community.domain.post.dto.response.PostAllReadResponse;
 import deepdivers.community.domain.post.dto.response.PostCreateResponse;
 import deepdivers.community.domain.post.dto.response.PostReadResponse;
 import deepdivers.community.domain.post.dto.response.PostUpdateResponse;
@@ -23,6 +24,7 @@ import deepdivers.community.domain.post.model.PostTitle;
 import deepdivers.community.domain.post.model.PostVisitor;
 import deepdivers.community.domain.post.repository.CategoryRepository;
 import deepdivers.community.domain.post.repository.CommentRepository;
+import deepdivers.community.domain.post.repository.PostQueryRepository;
 import deepdivers.community.domain.post.repository.PostRepository;
 import deepdivers.community.domain.post.repository.PostVisitorRepository;
 import deepdivers.community.domain.global.exception.model.BadRequestException;
@@ -46,6 +48,7 @@ public class PostService {
 	private final PostHashtagRepository postHashtagRepository;
 	private final PostVisitorRepository postVisitorRepository;
 	private final CommentRepository commentRepository;
+	private final PostQueryRepository postQueryRepository;
 
 	public API<PostCreateResponse> createPost(PostCreateRequest request, Member member) {
 		PostCategory postCategory = getCategoryById(request.categoryId());
@@ -56,11 +59,9 @@ public class PostService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<PostReadResponse> getAllPosts() {
-		List<Post> posts = postRepository.findAll();
-		return posts.stream()
-			.map(PostReadResponse::from)
-			.collect(Collectors.toList());
+	public List<PostAllReadResponse> getAllPosts(Long lastContentId, Long categoryId) {
+		System.out.println("PostService - getAllPosts 호출됨");
+		return postQueryRepository.findAllPosts(lastContentId, categoryId);
 	}
 
 	@Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #16, #66

## 📝작업 내용

> 카테고리 별 게시글 조회 API 기능 구현

### 스크린샷 (선택)
![카테고리별](https://github.com/user-attachments/assets/69837d15-291f-4962-9f8e-15d9a54c5440)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

> 프로젝트 구조 개선 방안
> 기능 구현 피드백
> 문법 오류 지적
